### PR TITLE
fix: enforce root block on external-only root selectors

### DIFF
--- a/packages/stylelint-plugin/__tests__/class-structure.root.test.ts
+++ b/packages/stylelint-plugin/__tests__/class-structure.root.test.ts
@@ -51,7 +51,7 @@ describe('spiracss/class-structure - root selectors include the root Block', () 
       true,
       withClassMode({
         elementDepth: 4,
-        external: { prefixes: ['u-'] },
+        external: { classes: ['swiper'], prefixes: ['u-'] },
         childCombinator: false,
         rootSingle: true,
         naming: { blockCase: 'kebab' }
@@ -77,8 +77,8 @@ describe('spiracss/class-structure - root selectors include the root Block', () 
         description: 'root Block remains valid even with compound selectors inside :is()'
       },
       {
-        code: '.tab-panels {}\n.u-hidden {}',
-        description: 'selectors with only external classes are excluded'
+        code: '.tab-panels.u-hidden {}',
+        description: 'external classes are allowed when root Block is included'
       },
       {
         code: '.tab-panels:has(:global(.foo)), .tab-panels:has(:global(.bar)) {}',
@@ -89,9 +89,15 @@ describe('spiracss/class-structure - root selectors include the root Block', () 
     reject: [
       {
         code: '.tab-panels {}\n.swiper {}',
-        description: 'top-level selector without root Block is an error',
+        description: 'external.classes selector without root Block is an error',
         message:
           'Root selector `.swiper` must include the root Block `.tab-panels`. Include it in the selector or move this rule under the root Block. (spiracss/class-structure)'
+      },
+      {
+        code: '.tab-panels {}\n.u-hidden {}',
+        description: 'external.prefixes selector without root Block is an error',
+        message:
+          'Root selector `.u-hidden` must include the root Block `.tab-panels`. Include it in the selector or move this rule under the root Block. (spiracss/class-structure)'
       },
       {
         code: '.tab-panels {}\n.foo:has(.tab-panels) {}',

--- a/packages/stylelint-plugin/src/rules/spiracss-class-structure.selectors.ts
+++ b/packages/stylelint-plugin/src/rules/spiracss-class-structure.selectors.ts
@@ -61,8 +61,12 @@ export const analyzeRootSelector = (
   rootBlockName: string,
   options: Options,
   patterns: Patterns
-): { hasSpiraClass: boolean; hasRootBlock: boolean; hasOtherBlock: boolean } => {
-  let hasSpiraClass = false
+): {
+  hasAnyClass: boolean
+  hasRootBlock: boolean
+  hasOtherBlock: boolean
+} => {
+  let hasAnyClass = false
   let hasRootBlock = false
   let hasOtherBlock = false
 
@@ -70,15 +74,15 @@ export const analyzeRootSelector = (
 
   sel.walk((node) => {
     if (!isClassNode(node)) return
+    hasAnyClass = true
     const name = node.value
     const kind = classify(name, options, patterns)
-    if (kind !== 'external') hasSpiraClass = true
     if (isInsideNonSameElementPseudo(node, sameElementPseudos)) return
     if (name === rootBlockName) hasRootBlock = true
     if (kind === 'block' && name !== rootBlockName) hasOtherBlock = true
   })
 
-  return { hasSpiraClass, hasRootBlock, hasOtherBlock }
+  return { hasAnyClass, hasRootBlock, hasOtherBlock }
 }
 
 type ProcessContext = {

--- a/packages/stylelint-plugin/src/rules/spiracss-class-structure.ts
+++ b/packages/stylelint-plugin/src/rules/spiracss-class-structure.ts
@@ -425,13 +425,13 @@ const rule = createRule(
           const selectors = parseStrippedSelectors(rule.selector)
           if (selectors.length === 0) return
           selectors.forEach((sel) => {
-            const { hasSpiraClass, hasRootBlock, hasOtherBlock } = analyzeRootSelector(
+            const { hasAnyClass, hasRootBlock, hasOtherBlock } = analyzeRootSelector(
               sel,
               resolvedRootBlockName,
               options,
               patterns
             )
-            if (!hasSpiraClass || hasRootBlock || hasOtherBlock) return
+            if (!hasAnyClass || hasRootBlock || hasOtherBlock) return
             stylelint.utils.report({
               ruleName,
               result,


### PR DESCRIPTION
## 概要
`spiracss/class-structure` の `rootSingle: true` チェックで、`external.classes` / `external.prefixes` のみを持つトップレベルセレクタが root Block 未包含でも通ってしまう問題を修正しました。

Issue: Closes #6

## 変更内容
- root selector 判定で `hasSpiraClass` 依存をやめ、`hasAnyClass` を導入
- クラスを含むトップレベルセレクタは、external-only であっても root Block 未包含なら `rootSelectorMissingBlock` を報告
- クラスを1つも含まないセレクタは従来どおり対象外
- ルート判定テストを更新
  - `external.classes: ['swiper']` で `.swiper` を reject
  - `external.prefixes: ['u-']` で `.u-hidden` を reject
  - `.tab-panels.u-hidden` は accept のまま

## テスト
- `cd packages/stylelint-plugin && npm test`
  - 655 passing
